### PR TITLE
Adding support for bsky.app as well

### DIFF
--- a/better-bsky-notifs.user.css
+++ b/better-bsky-notifs.user.css
@@ -7,7 +7,7 @@
 @license        MIT
 ==/UserStyle== */
 
-@-moz-document url("https://staging.bsky.app/notifications") {
+@-moz-document url("https://staging.bsky.app/notifications"), url("https://bsky.app/notifications") {
     /* IMPORTANT NOTE:
     This userstyle is entirely dependent on your profile's two IDs:
     - your domain handle, used to detect direct replies


### PR DESCRIPTION
Until staging.bsky.app goes away (I believe its planned to eventually redirect), this change will allow for the custom style to work for folks using the staging URL **or** the non-staging one.